### PR TITLE
Auto publish test

### DIFF
--- a/lib/ExpressionVisitor.ts
+++ b/lib/ExpressionVisitor.ts
@@ -71,7 +71,7 @@ export class ExpressionVisitor {
     }
 
     protected visitMember(exp: MemberExpression, scopes: any[]) {
-        return this.readVar(exp.member, [this.visit(exp.owner, scopes)])
+        return this.readVar(exp.name, [this.visit(exp.owner, scopes)])
     }
 
     protected visitObject(exp: ObjectExpression, scopes: any[]) {
@@ -99,7 +99,7 @@ export class ExpressionVisitor {
     }
 
     protected visitVariable(exp: VariableExpression, scopes: any[]) {
-        return this.readVar(exp, scopes);
+        return this.readVar(exp.name, scopes);
     }
 
     protected evalBinary(leftValue, operator: string, right: Expression, scopes: any[]) {
@@ -161,9 +161,9 @@ export class ExpressionVisitor {
         return [null, false];
     }
 
-    protected readVar(exp: VariableExpression, scopes: any[]) {
-        const s = scopes.find(s => s && exp.name in s);
-        const v = s && s[exp.name];
+    protected readVar(prop: string, scopes: any[]) {
+        const s = scopes.find(s => s && prop in s);
+        const v = s && s[prop];
         return (v && v.bind && typeof v.bind === 'function') ? v.bind(s) : v;
     }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -47,9 +47,8 @@ export interface ArrayExpression extends Expression {
     readonly items: Expression[];
 }
 
-export interface MemberExpression extends Expression {
+export interface MemberExpression extends VariableExpression {
     readonly owner: Expression;
-    readonly member: VariableExpression;
 }
 
 export interface IndexerExpression extends Expression {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jokenizer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Tokenize javascript expressions.",
   "main": "dist/index.js",
   "keywords": [

--- a/test/evaluator.spec.ts
+++ b/test/evaluator.spec.ts
@@ -68,9 +68,9 @@ describe('Evaluation tests', () => {
     });
 
     it('should evaluate object', () => {
-        const t = tokenize('{ a: v1, b }') as ObjectExpression;
-        const v = evaluate(t, { v1: 3, b: 5 });
-        expect(v).to.deep.equal({ a: 3, b: 5 });
+        const t = tokenize('{ a: v1, b.c }') as ObjectExpression;
+        const v = evaluate(t, { v1: 3, b: { c: 5 } });
+        expect(v).to.deep.equal({ a: 3, c: 5 });
     });
 
     it('should evaluate array', () => {


### PR DESCRIPTION
## Change list

* Improve ObjectExpression, adding inferred member name
 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

Now we can create ObjectExpression without left side
{ a.b.c }
will create the below AssignExpression 
c = a.b.c